### PR TITLE
LEAN-3278 Collab plugin compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.5",
+  "version": "1.7.5-LEAN-3278",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -100,6 +100,14 @@ export const trackChangesPlugin = (opts: TrackChangesOptions = { userID: 'anonym
       trs.forEach((tr) => {
         const wasAppended = tr.getMeta('appendedTransaction') as Transaction | undefined
         const skipMetaUsed = skipTrsWithMetas.some((m) => tr.getMeta(m) || wasAppended?.getMeta(m))
+
+        // track changes allows free reign for client sync, because, if the changes was supposed to be tracked it should've been done on the respective client.
+        const collabRebased = tr.getMeta('rebased')
+        if (collabRebased !== undefined) {
+          setAction(createdTr, TrackChangesAction.refreshChanges, true)
+          docChanged = true
+          return
+        }
         const skipTrackUsed =
           getAction(tr, TrackChangesAction.skipTrack) ||
           (wasAppended && getAction(wasAppended, TrackChangesAction.skipTrack))

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,7 +34,9 @@ export const trackChangesPluginKey = new PluginKey<TrackChangesState>('track-cha
  * Accepts an empty options object as an argument but note that this uses 'anonymous:Anonymous' as the default userID.
  * @param opts
  */
-export const trackChangesPlugin = (opts: TrackChangesOptions = { userID: 'anonymous:Anonymous' }) => {
+export const trackChangesPlugin = (
+  opts: TrackChangesOptions = { userID: 'anonymous:Anonymous', initialStatus: TrackChangesStatus.enabled }
+) => {
   const { userID, debug, skipTrsWithMetas = [] } = opts
   let editorView: EditorView | undefined
   if (debug) {
@@ -51,7 +53,7 @@ export const trackChangesPlugin = (opts: TrackChangesOptions = { userID: 'anonym
     state: {
       init(_config, state) {
         return {
-          status: TrackChangesStatus.enabled,
+          status: opts.initialStatus || TrackChangesStatus.enabled,
           userID,
           changeSet: findChanges(state),
         }

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -22,6 +22,7 @@ export interface TrackChangesOptions {
   debug?: boolean
   userID: string
   skipTrsWithMetas?: (PluginKey | string)[]
+  initialStatus?: TrackChangesStatus
 }
 
 export interface TrackChangesState {


### PR DESCRIPTION
1. Prevents the incoming changes from different clients to be considered as something what has to be processed as a tracked change. Without it opening several clients on the same document causes a limbo as client tracks an already tracked version and then the original client attempts to track a tracked version of a tracked version of that change and so on...

2. Allowing passing initial state so we can disable tracking based on the user role