### PR TITLE
LEAN-3136 Footnotes Improvements Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.9",
+  "version": "1.7.9-LEAN-3136-2MB",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.10-LEAN-3136-2MB-3",
+  "version": "1.7.11",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.10-LEAN-3136-2MB",
+  "version": "1.7.10-LEAN-3136-2MB-2",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.10-LEAN-3136-2MB-2",
+  "version": "1.7.10-LEAN-3136-2MB-3",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/mutate/deleteNode.ts
+++ b/src/mutate/deleteNode.ts
@@ -79,10 +79,17 @@ export function deleteOrSetNodeDeleted(
 ) {
   const dataTracked = getBlockInlineTrackedData(node)
   const inserted = dataTracked?.find(
-    (d) => d.operation === CHANGE_OPERATION.insert && (d.status === CHANGE_STATUS.pending || d.status === CHANGE_STATUS.accepted)
+    (d) =>
+      d.operation === CHANGE_OPERATION.insert &&
+      (d.status === CHANGE_STATUS.pending || d.status === CHANGE_STATUS.accepted)
   )
   const updated = dataTracked?.find((d) => d.operation === CHANGE_OPERATION.set_node_attributes)
-  if (inserted && inserted.authorID === deleteAttrs.authorID) {
+
+  /*
+    Removed condition "inserted.authorID === deleteAttrs.authorID" for this check because it resulted in a weird behaviour of deletion of approved changes
+    Approved changes handling are in the process of revision at the time of writing this comment.
+  */
+  if (inserted) {
     return deleteNode(node, pos, newTr)
   }
   if (!newTr.doc.nodeAt(pos)) {

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -170,7 +170,7 @@ export function trackTransaction(
     console.log('%c Getting into node select! ', 'background: #222; color: #bada55')
     // And -1 here is necessary to keep the selection pointing at the start of the node
     // (or something, breaks with cross-references otherwise)
-    const mappedPos = newTr.mapping.map(tr.selection.from)
+    const mappedPos = newTr.mapping.map(tr.selection.from, -1)
     const sel: typeof NodeSelection = getSelectionStaticConstructor(tr.selection)
     newTr.setSelection(sel.create(newTr.doc, mappedPos))
   }

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -16,17 +16,18 @@
 import { Node as PMNode } from 'prosemirror-model'
 import { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state'
 import { NodeSelection as NodeSelectionClass } from 'prosemirror-state'
-import { AddMarkStep, RemoveMarkStep, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
+import { AddMarkStep, Mapping, RemoveMarkStep, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
 import { diffChangeSteps } from '../change-steps/diffChangeSteps'
 import { processChangeSteps } from '../change-steps/processChangeSteps'
 import { CHANGE_STATUS } from '../types/change'
 import { ExposedReplaceStep } from '../types/pm'
-import { InsertSliceStep } from '../types/step'
+import { ChangeStep, InsertSliceStep } from '../types/step'
 import { NewEmptyAttrs } from '../types/track'
 import { log } from '../utils/logger'
 import { trackReplaceAroundStep } from './trackReplaceAroundStep'
 import { trackReplaceStep } from './trackReplaceStep'
+import { mapChangeSteps } from '../utils/mapChangeStep'
 /**
  * Retrieves a static property from Selection class instead of having to use direct imports
  *
@@ -80,6 +81,10 @@ export function trackTransaction(
     const step = tr.steps[i]
     log.info('transaction step', step)
     iters += 1
+    // if (iters == 1) {
+    //   console.log('skipping first step')
+    //   continue
+    // }
     if (iters > 20) {
       console.error(
         '@manuscripts/track-changes-plugin: Possible infinite loop in iterating tr.steps, tracking skipped!\n' +
@@ -99,9 +104,28 @@ export function trackTransaction(
         // don't track highlight marker nodes
         continue
       }
-      const newStep = step.invert(tr.docs[i])
+      const invertedStep = step.invert(tr.docs[i])
+
+      const thisStepMapping = tr.mapping.slice(i + 1)
+      /* 
+      In reference to "const thisStepMapping = tr.mapping.slice(i + 1)""
+      Remember that every step in a transaction is applied on top of the previous step in that transaction.
+      So here, during tracking processing, each step is intended for its own document but not for the final document - the tr.doc
+      Because of that when a step is processed it has to be remapped to all the steps that occured after it or it will be mismatched as if there were no steps after it.
+      This is apparent only in transactions with multiple insertions/deletions across the document and, withtout such mapping, if the last
+      step adds content before the first step, the plugin will attempt to insert tracked replacement for the first change at a position
+      that corresponds to the first change position if the second change (second in time but occuring earlier in doc) never occured.
+      */
+      // @TODO - check if needed to be done for other types of steps
+      const newStep = new ReplaceStep(
+        thisStepMapping.map(invertedStep.from),
+        thisStepMapping.map(invertedStep.to),
+        invertedStep.slice
+      )
       const stepResult = newTr.maybeStep(newStep)
+
       let [steps, startPos] = trackReplaceStep(step, oldState, newTr, emptyAttrs, stepResult, tr.docs[i])
+
       if (steps.length === 1) {
         const step: any = steps[0] // eslint-disable-line @typescript-eslint/no-explicit-any
         if (isHighlightMarkerNode(step?.node || step?.slice?.content?.content[0])) {
@@ -109,6 +133,10 @@ export function trackTransaction(
           continue
         }
       }
+
+      startPos = thisStepMapping.map(startPos)
+      steps = mapChangeSteps(steps, thisStepMapping)
+
       log.info('CHANGES: ', steps)
       // deleted and merged really...
       const deleted = steps.filter((s) => s.type !== 'insert-slice')

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Node as PMNode } from 'prosemirror-model'
-import type { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state'
+import { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state'
 import { NodeSelection as NodeSelectionClass } from 'prosemirror-state'
 import { AddMarkStep, RemoveMarkStep, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
@@ -72,6 +72,7 @@ export function trackTransaction(
   // Must use constructor.name instead of instanceof as aliasing prosemirror-state is a lot more
   // difficult than prosemirror-transform
   const wasNodeSelection = tr.selection instanceof NodeSelectionClass
+  const setsNewSelection = tr.selectionSet
   let iters = 0
   log.info('ORIGINAL transaction', tr)
 
@@ -121,11 +122,12 @@ export function trackTransaction(
         emptyAttrs,
         oldState.schema
       )
-      if (!wasNodeSelection) {
+      if (!wasNodeSelection && !setsNewSelection) {
         const sel: typeof Selection = getSelectionStaticConstructor(tr.selection)
         // Use Selection.near to fix selections that point to a block node instead of inline content
         // eg when inserting a complete new paragraph. -1 finds the first valid position moving backwards
         // inside the content
+
         const near: Selection = sel.near(newTr.doc.resolve(selectionPos), -1)
         newTr.setSelection(near)
       }
@@ -157,13 +159,18 @@ export function trackTransaction(
     tr.getMeta('inputType') && newTr.setMeta('inputType', tr.getMeta('inputType'))
     tr.getMeta('uiEvent') && newTr.setMeta('uiEvent', tr.getMeta('uiEvent'))
   }
+  if (setsNewSelection && tr.selection instanceof TextSelection) {
+    // preserving text selection if we track an element in which selection is set
+    const newPos = newTr.doc.resolve(tr.selection.from) // no mapping on purpose as tracking will misguide mapping
+    newTr.setSelection(new TextSelection(newPos))
+  }
   // This is kinda hacky solution at the moment to maintain NodeSelections over transactions
   // These are required by at least cross-references and links to activate their selector pop-ups
   if (wasNodeSelection) {
     console.log('%c Getting into node select! ', 'background: #222; color: #bada55')
     // And -1 here is necessary to keep the selection pointing at the start of the node
     // (or something, breaks with cross-references otherwise)
-    const mappedPos = newTr.mapping.map(tr.selection.from, -1)
+    const mappedPos = newTr.mapping.map(tr.selection.from)
     const sel: typeof NodeSelection = getSelectionStaticConstructor(tr.selection)
     newTr.setSelection(sel.create(newTr.doc, mappedPos))
   }

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 import { Node as PMNode } from 'prosemirror-model'
-import { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state'
-import { NodeSelection as NodeSelectionClass } from 'prosemirror-state'
+import {
+  EditorState,
+  NodeSelection,
+  NodeSelection as NodeSelectionClass,
+  Selection,
+  TextSelection,
+  Transaction,
+} from 'prosemirror-state'
 import { AddMarkStep, Mapping, RemoveMarkStep, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
 import { diffChangeSteps } from '../change-steps/diffChangeSteps'
@@ -25,9 +31,9 @@ import { ExposedReplaceStep } from '../types/pm'
 import { ChangeStep, InsertSliceStep } from '../types/step'
 import { NewEmptyAttrs } from '../types/track'
 import { log } from '../utils/logger'
+import { mapChangeSteps } from '../utils/mapChangeStep'
 import { trackReplaceAroundStep } from './trackReplaceAroundStep'
 import { trackReplaceStep } from './trackReplaceStep'
-import { mapChangeSteps } from '../utils/mapChangeStep'
 /**
  * Retrieves a static property from Selection class instead of having to use direct imports
  *

--- a/src/utils/mapChangeStep.ts
+++ b/src/utils/mapChangeStep.ts
@@ -1,0 +1,40 @@
+/*!
+ * © 2023 Atypon Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Mapping } from 'prosemirror-transform'
+
+import { ChangeStep } from '../types/step'
+
+export function mapChangeSteps(steps: ChangeStep[], mapping: Mapping) {
+  steps.forEach((step) => {
+    if ('from' in step) {
+      step.from = mapping.map(step.from)
+    }
+    if ('to' in step) {
+      step.to = mapping.map(step.to)
+    }
+    if ('pos' in step) {
+      step.pos = mapping.map(step.pos)
+    }
+    if ('nodeEnd' in step) {
+      step.nodeEnd = mapping.map(step.nodeEnd)
+    }
+    if ('mergePos' in step) {
+      step.mergePos = mapping.map(step.mergePos)
+    }
+  })
+  return steps
+}


### PR DESCRIPTION
This fixes cases when TC plugin corrupts selection that was set in a transaction that inserts/deletes content.

Additionally it fixes cases when several steps on the same transaction is are not tracked correctly (creates duplicated content) if last steps in the transaction add content positioned before the first change in the transaction and track changes plugin tries to replace original with tracked content at a mismatched position.