### PR TITLE
Support tracking multiple steps in the same transaction (LEAN-3643)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -79,9 +79,23 @@ export class ChangeSet {
       ) {
         currentNodeChange.children.push(c)
       } else if (c.type === 'node-change') {
-        currentNodeChange = { ...c, children: [] }
+        // check if this change belongs to a previously pushed root
+        const result = this.matchAndAddToRootChange(rootNodes, c)
+        if (result) {
+          const { index, root } = result
+          rootNodes[index] = root
+        } else {
+          currentNodeChange = { ...c, children: [] }
+        }
       } else {
-        rootNodes.push(c)
+        // check if this change belongs to a previously pushed root
+        const result = this.matchAndAddToRootChange(rootNodes, c)
+        if (result) {
+          const { index, root } = result
+          rootNodes[index] = root
+        } else {
+          rootNodes.push(c)
+        }
       }
     })
     if (currentNodeChange) {
@@ -160,6 +174,20 @@ export class ChangeSet {
     return this.#changes.filter((c) => ids.includes(c.id))
   }
 
+  // Searches for a root change for the given change in the rootNodes and updates the root by pushing the new change if it belongs to it.
+  matchAndAddToRootChange(rootNodes: TrackedChange[], change: TrackedChange) {
+    for (let i = 0; i < rootNodes.length; i++) {
+      const root = rootNodes[i] as NodeChange
+      if (
+        root.type === 'node-change' &&
+        change.from < root.to &&
+        change.dataTracked.statusUpdateAt === root.dataTracked.statusUpdateAt
+      ) {
+        root.children.push(change)
+        return { index: i, root }
+      }
+    }
+  }
   /**
    * Flattens a changeTree into a list of IDs
    * @param changes

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Slice } from 'prosemirror-model'
+import { Node as PMNode, Slice } from 'prosemirror-model'
 import type { EditorState, Transaction } from 'prosemirror-state'
-import { ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
+import { Mapping, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
 import { TrackChangesAction } from '../actions'
 import { setFragmentAsInserted } from '../compute/setFragmentAsInserted'
@@ -32,7 +32,8 @@ export function trackReplaceAroundStep(
   oldState: EditorState,
   tr: Transaction,
   newTr: Transaction,
-  attrs: NewEmptyAttrs
+  attrs: NewEmptyAttrs,
+  currentStepDoc: PMNode
 ) {
   log.info('###### ReplaceAroundStep ######')
   // @ts-ignore
@@ -54,13 +55,13 @@ export function trackReplaceAroundStep(
     slice: ExposedSlice
   } = step
   // Invert the transaction step to prevent it from actually deleting or inserting anything
-  const newStep = step.invert(oldState.doc)
+  const newStep = step.invert(currentStepDoc)
   const stepResult = newTr.maybeStep(newStep)
   if (stepResult.failed) {
     log.error(`inverting ReplaceAroundStep failed: "${stepResult.failed}"`, newStep)
     return []
   }
-  const gap = oldState.doc.slice(gapFrom, gapTo)
+  const gap = currentStepDoc.slice(gapFrom, gapTo)
   log.info('RETAINED GAP CONTENT', gap)
   // First apply the deleted range and update the insert slice to not include content that was deleted,
   // eg partial nodes in an open-ended slice

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -15,12 +15,11 @@
  */
 import { Node as PMNode, Slice } from 'prosemirror-model'
 import type { EditorState, Transaction } from 'prosemirror-state'
-import { Mapping, ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
+import { ReplaceAroundStep } from 'prosemirror-transform'
 
 import { TrackChangesAction } from '../actions'
 import { setFragmentAsInserted } from '../compute/setFragmentAsInserted'
 import { deleteAndMergeSplitNodes } from '../mutate/deleteAndMergeSplitNodes'
-import { mergeTrackedMarks } from '../mutate/mergeTrackedMarks'
 import { ExposedSlice } from '../types/pm'
 import { ChangeStep } from '../types/step'
 import { NewEmptyAttrs } from '../types/track'

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -57,6 +57,7 @@ export function trackReplaceAroundStep(
   const newStep = step.invert(currentStepDoc)
   const stepResult = newTr.maybeStep(newStep)
   if (stepResult.failed) {
+    // for some cases invert will fail due to sending multiple steps that update the same nodes
     log.error(`inverting ReplaceAroundStep failed: "${stepResult.failed}"`, newStep)
     return []
   }

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -166,7 +166,7 @@ export function trackTransaction(
         newTr.setSelection(near)
       }
     } else if (step instanceof ReplaceAroundStep) {
-      let steps = trackReplaceAroundStep(step, oldState, tr, newTr, emptyAttrs)
+      let steps = trackReplaceAroundStep(step, oldState, tr, newTr, emptyAttrs, tr.docs[i])
       const deleted = steps.filter((s) => s.type !== 'insert-slice')
       const inserted = steps.filter((s) => s.type === 'insert-slice') as InsertSliceStep[]
       log.info('INSERT STEPS: ', inserted)

--- a/test/__fixtures__/list.json
+++ b/test/__fixtures__/list.json
@@ -159,6 +159,54 @@
     {
       "type": "paragraph",
       "attrs": {
+        "id": "MPParagraphElement:6B541017-DC6A-44A7-A67A-DD599D171E64",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "1",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
+        "id": "MPParagraphElement:C6F0DA83-246A-460F-8D43-1E56C9027FFE",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "2",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
+        "id": "MPParagraphElement:9CFDF5FE-66D6-4726-A914-074D57B2DADB",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "3",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
         "id": "MPParagraphElement:AB306236-74E2-4FE5-976D-7A1B6CD94D5F",
         "comments": [],
         "dataTracked": null,

--- a/test/nodes/nodes.test.ts
+++ b/test/nodes/nodes.test.ts
@@ -231,6 +231,19 @@ describe('nodes.test', () => {
     expect(log.error).toHaveBeenCalledTimes(0)
   })
 
+  // TODO:: this example of sending multiple steps in one transaction for the same node. it's going to be a reference to fix it later
+  test.skip('should track inserting list with with multiple paragraph selected', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(37, 44)
+      .wrapInList(schema.nodes.bullet_list)
+
+    expect(tester.trackState()?.changeSet.hasInconsistentData).toEqual(false)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
   test.skip('should track node attribute updates', async () => {
     const tester = setupEditor({
       doc: docs.paragraph,

--- a/test/utils/PMTestChain.ts
+++ b/test/utils/PMTestChain.ts
@@ -17,7 +17,7 @@ import { wrapIn } from 'prosemirror-commands'
 // import {lift, joinUp, selectParentNode, wrapIn, setBlockType} from "prosemirror-commands"
 import { exampleSetup } from 'prosemirror-example-setup'
 import { Mark, Node as PMNode, NodeRange, NodeType, Schema, Slice } from 'prosemirror-model'
-import { liftListItem, sinkListItem } from 'prosemirror-schema-list'
+import { liftListItem, sinkListItem, wrapInList } from 'prosemirror-schema-list'
 import { EditorState, Plugin, TextSelection, Transaction } from 'prosemirror-state'
 import { findWrapping } from 'prosemirror-transform'
 import { EditorView } from 'prosemirror-view'
@@ -186,6 +186,11 @@ export class ProsemirrorTestChain {
         wrapping = findWrapping(range, nodeType, attrs)
       wrapping && dispatch(state.tr.wrap(range, wrapping))
     })
+    return this
+  }
+
+  wrapInList(nodeType: NodeType) {
+    this.cmd(wrapInList(nodeType))
     return this
   }
 


### PR DESCRIPTION
Tracking multiple steps on the same node will not work like the case of [wrapInList](https://github.com/Atypon-OpenSource/manuscripts-body-editor/blob/master/src/commands.ts#L926) command. I tried to call `processChangeSteps` after we reverted all the steps that will fix that issue but will not work for other cases that need to update the positions of subsequent steps and the mapping will not help us to update steps position.

I don't want to blow up the current process that handles the steps as it makes sense to revert the step and apply it to the new transaction one by one. if the user wants to update one node with multiple steps he needs to do it with multiple transactions