### PR TITLE
LEAN-3824:LW-FY25-Q1: Multiple suggestions are showing when copy/ pas…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.17",
+  "version": "1.7.18-LEAN-3824.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -206,7 +206,8 @@ export class ChangeSet {
     return (
       currentChange.to === nextChange.from &&
       ChangeSet.isTextChange(currentChange) &&
-      ChangeSet.isTextChange(nextChange)
+      ChangeSet.isTextChange(nextChange) &&
+      currentChange.dataTracked.status === nextChange.dataTracked.status
     )
   }
   /**


### PR DESCRIPTION
Issue: Multiple suggestions were appearing when copying and pasting text with multiple formats (marks) because in ProseMirror we can't merge multiple text nodes with different marks into a single text node.

The issue was resolved by implementing new method to detect when consecutive text changes should be merged based on their position and type. This ensures that all related text changes are combined into a single suggestion across multiple paste operations.

