### PR TITLE
TCE-030 - Split paragraphs support (LEAN-3893)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.23-LEAN-3893.0",
+  "version": "1.7.23-LEAN-3893.1",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.23-LEAN-3893.2",
+  "version": "1.7.23-LEAN-3893.3",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.23-LEAN-3893.3",
+  "version": "1.7.23",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.22",
+  "version": "1.7.23-LEAN-3893.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.23-LEAN-3893.1",
+  "version": "1.7.23-LEAN-3893.2",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -19,6 +19,7 @@ import {
   IncompleteChange,
   NodeAttrChange,
   NodeChange,
+  SplitSourceChange,
   TextChange,
   TrackedAttrs,
   TrackedChange,
@@ -130,7 +131,9 @@ export class ChangeSet {
   }
 
   get bothNodeChanges() {
-    return this.changes.filter((c) => c.type === 'node-change' || c.type === 'node-attr-change')
+    return this.changes.filter(
+      (c) => c.type === 'node-change' || c.type === 'split-source' || c.type === 'node-attr-change'
+    )
   }
 
   get isEmpty() {
@@ -256,6 +259,10 @@ export class ChangeSet {
 
   static isNodeAttrChange(change: TrackedChange): change is NodeAttrChange {
     return change.type === 'node-attr-change'
+  }
+
+  static isSplitSourceChange(change: TrackedChange): change is SplitSourceChange {
+    return change.type === 'split-source'
   }
 
   #isSameNodeChange(currentChange: NodeChange, nextChange: TrackedChange) {

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -19,7 +19,7 @@ import {
   IncompleteChange,
   NodeAttrChange,
   NodeChange,
-  SplitSourceChange,
+  ReferenceChange,
   TextChange,
   TrackedAttrs,
   TrackedChange,
@@ -132,7 +132,7 @@ export class ChangeSet {
 
   get bothNodeChanges() {
     return this.changes.filter(
-      (c) => c.type === 'node-change' || c.type === 'split-source' || c.type === 'node-attr-change'
+      (c) => c.type === 'node-change' || c.type === 'reference-change' || c.type === 'node-attr-change'
     )
   }
 
@@ -261,8 +261,8 @@ export class ChangeSet {
     return change.type === 'node-attr-change'
   }
 
-  static isSplitSourceChange(change: TrackedChange): change is SplitSourceChange {
-    return change.type === 'split-source'
+  static isReferenceChange(change: TrackedChange): change is ReferenceChange {
+    return change.type === 'reference-change'
   }
 
   #isSameNodeChange(currentChange: NodeChange, nextChange: TrackedChange) {

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -203,7 +203,10 @@ export class ChangeSet {
   static shouldDeleteChange(change: TrackedChange) {
     const { status, operation } = change.dataTracked
     return (
-      (operation === CHANGE_OPERATION.insert && status === CHANGE_STATUS.rejected) ||
+      ((operation === CHANGE_OPERATION.insert ||
+        operation === CHANGE_OPERATION.node_split ||
+        operation === CHANGE_OPERATION.wrap_with_node) &&
+        status === CHANGE_STATUS.rejected) ||
       (operation === CHANGE_OPERATION.delete && status === CHANGE_STATUS.accepted)
     )
   }

--- a/src/change-steps/processChangeSteps.ts
+++ b/src/change-steps/processChangeSteps.ts
@@ -75,6 +75,14 @@ export function processChangeSteps(
           return
         }
 
+        if (
+          node.marks.find(
+            (m) => m.attrs.dataTracked && m.attrs.dataTracked.operation === CHANGE_OPERATION.node_split
+          )
+        ) {
+          return
+        }
+
         const where = deleteTextIfInserted(
           node,
           mapping.map(c.pos),

--- a/src/change-steps/processChangeSteps.ts
+++ b/src/change-steps/processChangeSteps.ts
@@ -75,14 +75,6 @@ export function processChangeSteps(
           return
         }
 
-        if (
-          node.marks.find(
-            (m) => m.attrs.dataTracked && m.attrs.dataTracked.operation === CHANGE_OPERATION.node_split
-          )
-        ) {
-          return
-        }
-
         const where = deleteTextIfInserted(
           node,
           mapping.map(c.pos),

--- a/src/change-steps/processChangeSteps.ts
+++ b/src/change-steps/processChangeSteps.ts
@@ -184,7 +184,9 @@ export function processChangeSteps(
           (JSON.stringify(oldAttrs) !== JSON.stringify(c.newAttrs) ||
             c.node.type === c.node.type.schema.nodes.citation) &&
           !oldDataTracked.find(
-            (d) => d.operation === CHANGE_OPERATION.insert && d.status === CHANGE_STATUS.pending
+            (d) =>
+              (d.operation === CHANGE_OPERATION.insert || d.operation === CHANGE_OPERATION.wrap_with_node) &&
+              d.status === CHANGE_STATUS.pending
           )
         ) {
           newDataTracked.push(newUpdate)

--- a/src/change-steps/processChangeSteps.ts
+++ b/src/change-steps/processChangeSteps.ts
@@ -159,11 +159,9 @@ export function processChangeSteps(
         const sourceAttrs = oldUpdate?.oldAttrs || c.node.attrs
         const { dataTracked, ...restAttrs } = sourceAttrs
         const oldAttrs = lastChangeRejected ? oldUpdate.oldAttrs : restAttrs
-        // if the node is list, we need to track only the last change. TODO refactor the update-node-attrs to handle all edge cases such as lists.
-        const newDataTracked =
-          c.node.type != c.node.type.schema.nodes.list
-            ? [...oldDataTracked.filter((d) => !oldUpdate || d.id !== oldUpdate.id || lastChangeRejected)]
-            : []
+        const newDataTracked = [
+          ...oldDataTracked.filter((d) => !oldUpdate || d.id !== oldUpdate.id || lastChangeRejected),
+        ]
         const newUpdate =
           oldUpdate && oldUpdate.status !== CHANGE_STATUS.rejected
             ? {

--- a/src/changes/applyChanges.ts
+++ b/src/changes/applyChanges.ts
@@ -24,7 +24,7 @@ import { CHANGE_STATUS, TrackedAttrs, TrackedChange } from '../types/change'
 import { log } from '../utils/logger'
 import { updateChangeChildrenAttributes } from './updateChangeAttrs'
 
-function getUpdatedDataTracked(dataTracked: TrackedAttrs[] | null, changeId: string) {
+export function getUpdatedDataTracked(dataTracked: TrackedAttrs[] | null, changeId: string) {
   if (!dataTracked) {
     return null
   }
@@ -137,6 +137,14 @@ export function applyAcceptedRejectedChanges(
         node.marks
       )
       addAttrLog(node.attrs.id, change.dataTracked.id)
+    } else if (ChangeSet.isSplitSourceChange(change)) {
+      const attrs = { ...node.attrs, dataTracked: null }
+      tr.setNodeMarkup(
+        from,
+        undefined,
+        { ...attrs, dataTracked: getUpdatedDataTracked(node.attrs.dataTracked, change.id) },
+        node.marks
+      )
     }
   })
   return deleteMap

--- a/src/changes/applyChanges.ts
+++ b/src/changes/applyChanges.ts
@@ -137,7 +137,7 @@ export function applyAcceptedRejectedChanges(
         node.marks
       )
       addAttrLog(node.attrs.id, change.dataTracked.id)
-    } else if (ChangeSet.isSplitSourceChange(change)) {
+    } else if (ChangeSet.isReferenceChange(change)) {
       const attrs = { ...node.attrs, dataTracked: null }
       tr.setNodeMarkup(
         from,

--- a/src/changes/findChanges.ts
+++ b/src/changes/findChanges.ts
@@ -24,6 +24,7 @@ import {
   NodeAttrChange,
   NodeChange,
   PartialChange,
+  SplitSourceChange,
   TextChange,
 } from '../types/change'
 
@@ -83,6 +84,14 @@ export function findChanges(state: EditorState) {
           newAttrs: node.attrs,
           oldAttrs: dataTracked.oldAttrs,
         } as NodeAttrChange
+      } else if (dataTracked.operation === CHANGE_OPERATION.split_source) {
+        change = {
+          id,
+          type: 'split-source',
+          from: pos,
+          to: pos + node.nodeSize,
+          dataTracked,
+        } as SplitSourceChange
       } else {
         change = {
           id,

--- a/src/changes/findChanges.ts
+++ b/src/changes/findChanges.ts
@@ -24,7 +24,7 @@ import {
   NodeAttrChange,
   NodeChange,
   PartialChange,
-  SplitSourceChange,
+  ReferenceChange,
   TextChange,
 } from '../types/change'
 
@@ -84,14 +84,14 @@ export function findChanges(state: EditorState) {
           newAttrs: node.attrs,
           oldAttrs: dataTracked.oldAttrs,
         } as NodeAttrChange
-      } else if (dataTracked.operation === CHANGE_OPERATION.split_source) {
+      } else if (dataTracked.operation === CHANGE_OPERATION.reference) {
         change = {
           id,
-          type: 'split-source',
+          type: 'reference-change',
           from: pos,
           to: pos + node.nodeSize,
           dataTracked,
-        } as SplitSourceChange
+        } as ReferenceChange
       } else {
         change = {
           id,

--- a/src/changes/revertChange.ts
+++ b/src/changes/revertChange.ts
@@ -46,23 +46,19 @@ function revertSplitNodeChange(
 
   if (splitPos && splitNode) {
     const node = tr.doc.nodeAt(change.from) as ManuscriptNode
-      tr.replaceWith(
-        change.from,
-        change.to,
-        node.replace(0, node.content.size, Slice.maxOpen(Fragment.empty))
-      )
-      tr.replaceWith(splitPos, splitPos + 1, node.content)
+    tr.replaceWith(change.from, change.to, node.replace(0, node.content.size, Slice.maxOpen(Fragment.empty)))
+    tr.replaceWith(splitPos, splitPos + 1, node.content)
   }
 }
 
 function revertWrapNodeChange(tr: Transaction, change: IncompleteChange, status: CHANGE_STATUS) {
-    let content = Fragment.from()
-    const node = tr.doc.nodeAt(change.from)!
-    node.content.forEach((node) => {
-      content = content.append(node.content)
-    })
-    tr.replaceWith(change.from, change.to, node.type.create(node.attrs, null, node.marks))
-    tr.insert(tr.mapping.map(change.to), content)
+  let content = Fragment.from()
+  const node = tr.doc.nodeAt(change.from)!
+  node.content.forEach((node) => {
+    content = content.append(node.content)
+  })
+  tr.replaceWith(change.from, change.to, node.type.create(node.attrs, null, node.marks))
+  tr.insert(tr.mapping.map(change.to), content)
 }
 
 export function revertRejectedChanges(

--- a/src/changes/revertChange.ts
+++ b/src/changes/revertChange.ts
@@ -35,7 +35,7 @@ function revertSplitNodeChange(tr: Transaction, change: IncompleteChange, change
   tr.replaceWith(change.from, change.to, Fragment.empty)
   tr.replaceWith(sourceChange.to - 1, sourceChange.to, node.content)
 
-  if ((change as NodeChange).nodeType === 'list_item') {
+  if ((change as NodeChange).node.type.name === 'list_item') {
     tr.join(sourceChange.to - 1)
   }
 

--- a/src/changes/revertChange.ts
+++ b/src/changes/revertChange.ts
@@ -1,0 +1,92 @@
+/*!
+ * © 2024 Atypon Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ManuscriptNode } from '@manuscripts/transform'
+import { Fragment, Schema, Slice } from 'prosemirror-model'
+import { Transaction } from 'prosemirror-state'
+
+import { ChangeSet } from '../ChangeSet'
+import { CHANGE_OPERATION, CHANGE_STATUS, IncompleteChange, NodeSplitAttrs } from "../types/change";
+
+function revertSplitNodeChange(
+  tr: Transaction,
+  change: IncompleteChange,
+  status: CHANGE_STATUS,
+  schema: Schema
+) {
+  let splitPos, splitNode
+
+  tr.doc.content.descendants((node, pos, parent) => {
+    if (node.isText) {
+      const splitMark = node.marks.find(
+        (m) =>
+          m.type === schema.marks.tracked_insert &&
+          m.attrs.dataTracked &&
+          m.attrs.dataTracked.id === (change.dataTracked as NodeSplitAttrs).splitMarkerId
+      )
+      if (splitMark) {
+        splitPos = pos
+        splitNode = parent!
+      }
+      return false
+    }
+  })
+
+  if (splitPos && splitNode) {
+    const node = tr.doc.nodeAt(change.from) as ManuscriptNode
+    if (status === CHANGE_STATUS.rejected) {
+      tr.replaceWith(
+        change.from,
+        change.to,
+        node.replace(0, node.content.size, Slice.maxOpen(Fragment.empty))
+      )
+      tr.replaceWith(splitPos, splitPos + 1, node.content)
+    }
+  }
+}
+
+function revertWrapNodeChange(tr: Transaction, change: IncompleteChange, status: CHANGE_STATUS) {
+  if (status === CHANGE_STATUS.rejected) {
+    let content = Fragment.from()
+    const node = tr.doc.nodeAt(change.from)!
+    node.content.forEach((node) => {
+      content = content.append(node.content)
+    })
+    tr.replaceWith(change.from, change.to, node.type.create(node.attrs, null, node.marks))
+    tr.insert(tr.mapping.map(change.to), content)
+  }
+}
+
+export function revertRejectedChanges(
+  tr: Transaction,
+  schema: Schema,
+  ids: string[],
+  changeSet: ChangeSet,
+  status: CHANGE_STATUS
+) {
+  if (status !== CHANGE_STATUS.rejected) {
+    return
+  }
+
+  ids.forEach((id) => {
+    const change = changeSet?.get(id)!
+    if (change.dataTracked.operation === CHANGE_OPERATION.node_split) {
+      revertSplitNodeChange(tr, change, status, schema)
+    }
+    if (change.dataTracked.operation === CHANGE_OPERATION.wrap_with_node) {
+      revertWrapNodeChange(tr, change, status)
+    }
+  })
+}

--- a/src/changes/revertChange.ts
+++ b/src/changes/revertChange.ts
@@ -73,7 +73,7 @@ export function revertRejectedChanges(
   }
 
   ids.forEach((id) => {
-    const change = changeSet?.get(id)!
+    const change = changeSet.get(id)!
     if (change.dataTracked.operation === CHANGE_OPERATION.node_split) {
       revertSplitNodeChange(tr, change, status, schema)
     }

--- a/src/changes/revertChange.ts
+++ b/src/changes/revertChange.ts
@@ -18,7 +18,7 @@ import { Fragment, Schema, Slice } from 'prosemirror-model'
 import { Transaction } from 'prosemirror-state'
 
 import { ChangeSet } from '../ChangeSet'
-import { CHANGE_OPERATION, CHANGE_STATUS, IncompleteChange, NodeSplitAttrs } from "../types/change";
+import { CHANGE_OPERATION, CHANGE_STATUS, IncompleteChange, NodeSplitAttrs } from '../types/change'
 
 function revertSplitNodeChange(
   tr: Transaction,
@@ -46,19 +46,16 @@ function revertSplitNodeChange(
 
   if (splitPos && splitNode) {
     const node = tr.doc.nodeAt(change.from) as ManuscriptNode
-    if (status === CHANGE_STATUS.rejected) {
       tr.replaceWith(
         change.from,
         change.to,
         node.replace(0, node.content.size, Slice.maxOpen(Fragment.empty))
       )
       tr.replaceWith(splitPos, splitPos + 1, node.content)
-    }
   }
 }
 
 function revertWrapNodeChange(tr: Transaction, change: IncompleteChange, status: CHANGE_STATUS) {
-  if (status === CHANGE_STATUS.rejected) {
     let content = Fragment.from()
     const node = tr.doc.nodeAt(change.from)!
     node.content.forEach((node) => {
@@ -66,7 +63,6 @@ function revertWrapNodeChange(tr: Transaction, change: IncompleteChange, status:
     })
     tr.replaceWith(change.from, change.to, node.type.create(node.attrs, null, node.marks))
     tr.insert(tr.mapping.map(change.to), content)
-  }
 }
 
 export function revertRejectedChanges(

--- a/src/compute/setFragmentAsInserted.ts
+++ b/src/compute/setFragmentAsInserted.ts
@@ -134,7 +134,11 @@ export function setFragmentAsNodeSplit(
     ...parent.attrs,
     dataTracked: [
       ...oldDataTracked.filter((c) => c.operation !== 'split_source'),
-      { ...trackUtils.createNewSplitSourceAttrs({ ...attrs, status: CHANGE_STATUS.rejected }, referenceId) },
+      {
+        ...addTrackIdIfDoesntExist(
+          trackUtils.createNewSplitSourceAttrs({ ...attrs, status: CHANGE_STATUS.rejected }, referenceId)
+        ),
+      },
     ],
   })
 

--- a/src/compute/setFragmentAsInserted.ts
+++ b/src/compute/setFragmentAsInserted.ts
@@ -127,13 +127,14 @@ export function setFragmentAsNodeSplit(
   const lastChild = inserted.lastChild!
   const referenceId = uuidv4()
 
-  const parentPos = $pos.before($pos.depth)
-  const parent = $pos.node($pos.depth)
+  const listItemSplit = lastChild.type.name === 'list_item' ? 1 : 0
+  const parentPos = $pos.before($pos.depth - listItemSplit)
+  const parent = $pos.node($pos.depth - listItemSplit)
   const oldDataTracked = getBlockInlineTrackedData(parent) || []
   newTr.setNodeMarkup(parentPos, undefined, {
     ...parent.attrs,
     dataTracked: [
-      ...oldDataTracked.filter((c) => c.operation !== 'split_source'),
+      ...oldDataTracked.filter((c) => c.operation !== 'reference'),
       {
         ...addTrackIdIfDoesntExist(
           trackUtils.createNewSplitSourceAttrs({ ...attrs, status: CHANGE_STATUS.rejected }, referenceId)
@@ -143,7 +144,7 @@ export function setFragmentAsNodeSplit(
   })
 
   // if the node has already split reference will move it to the new split
-  const splitSource = oldDataTracked.find((c) => c.operation === 'split_source')
+  const splitSource = oldDataTracked.find((c) => c.operation === 'reference')
   const dataTracked = { ...trackUtils.createNewSplitAttrs({ ...attrs }), id: referenceId }
   inserted = inserted.replaceChild(
     inserted.childCount - 1,

--- a/src/mutate/deleteNode.ts
+++ b/src/mutate/deleteNode.ts
@@ -84,8 +84,7 @@ export function deleteOrSetNodeDeleted(
       (d.status === CHANGE_STATUS.pending || d.status === CHANGE_STATUS.accepted)
   )
   const updated = dataTracked?.find(
-    (d) =>
-      d.operation === CHANGE_OPERATION.set_node_attributes || d.operation === CHANGE_OPERATION.split_source
+    (d) => d.operation === CHANGE_OPERATION.set_node_attributes || d.operation === CHANGE_OPERATION.reference
   )
 
   /*

--- a/src/mutate/deleteNode.ts
+++ b/src/mutate/deleteNode.ts
@@ -80,10 +80,13 @@ export function deleteOrSetNodeDeleted(
   const dataTracked = getBlockInlineTrackedData(node)
   const inserted = dataTracked?.find(
     (d) =>
-      d.operation === CHANGE_OPERATION.insert &&
+      (d.operation === CHANGE_OPERATION.insert || d.operation === CHANGE_OPERATION.wrap_with_node) &&
       (d.status === CHANGE_STATUS.pending || d.status === CHANGE_STATUS.accepted)
   )
-  const updated = dataTracked?.find((d) => d.operation === CHANGE_OPERATION.set_node_attributes)
+  const updated = dataTracked?.find(
+    (d) =>
+      d.operation === CHANGE_OPERATION.set_node_attributes || d.operation === CHANGE_OPERATION.split_source
+  )
 
   /*
     Removed condition "inserted.authorID === deleteAttrs.authorID" for this check because it resulted in a weird behaviour of deletion of approved changes

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,6 +20,7 @@ import { getAction, hasAction, setAction, TrackChangesAction } from './actions'
 import { applyAcceptedRejectedChanges } from './changes/applyChanges'
 import { findChanges } from './changes/findChanges'
 import { fixInconsistentChanges } from './changes/fixInconsistentChanges'
+import { revertRejectedChanges } from './changes/revertChange'
 import { updateChangeAttrs } from './changes/updateChangeAttrs'
 import { ChangeSet } from './ChangeSet'
 import { trackTransaction } from './steps/trackTransaction'
@@ -148,6 +149,7 @@ export const trackChangesPlugin = (
               )
             }
           })
+          revertRejectedChanges(createdTr, oldState.schema, ids, changeSet, status)
         } else if (getAction(tr, TrackChangesAction.applyAndRemoveChanges)) {
           const mapping = applyAcceptedRejectedChanges(createdTr, oldState.schema, changeSet.bothNodeChanges)
           applyAcceptedRejectedChanges(createdTr, oldState.schema, changeSet.textChanges, mapping)

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -26,6 +26,7 @@ import { ChangeStep } from '../types/step'
 import { NewEmptyAttrs } from '../types/track'
 import { log } from '../utils/logger'
 import * as trackUtils from '../utils/track-utils'
+import { isWrapStep } from '../utils/track-utils'
 
 export function trackReplaceAroundStep(
   step: ReplaceAroundStep,
@@ -87,9 +88,7 @@ export function trackReplaceAroundStep(
     oldState.schema
   )
 
-  const isWrapStep = step.from === step.gapFrom && step.to === step.gapTo && newSliceContent.size === 0;
-
-  if (isWrapStep) {
+  if (isWrapStep(step, newSliceContent)) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
   }
 

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -87,7 +87,9 @@ export function trackReplaceAroundStep(
     oldState.schema
   )
 
-  if (step.from === step.gapFrom && step.to === step.gapTo && newSliceContent.size === 0) {
+  const isWrapStep = step.from === step.gapFrom && step.to === step.gapTo && newSliceContent.size === 0;
+
+  if (isWrapStep) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
   }
 

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -82,14 +82,11 @@ export function trackReplaceAroundStep(
     slice
   )
 
-  let fragment = setFragmentAsInserted(
-    newSliceContent,
-    trackUtils.createNewInsertAttrs(attrs),
-    oldState.schema
-  )
-
-  if (isWrapStep(step, newSliceContent)) {
+  let fragment
+  if (isWrapStep(step)) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
+  } else {
+    fragment = setFragmentAsInserted(newSliceContent, trackUtils.createNewInsertAttrs(attrs), oldState.schema)
   }
 
   const steps: ChangeStep[] = deleteSteps

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -87,7 +87,7 @@ export function trackReplaceAroundStep(
     oldState.schema
   )
 
-  if (step.from === step.gapFrom && step.to === step.gapTo) {
+  if (step.from === step.gapFrom && step.to === step.gapTo && newSliceContent.size === 0) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
   }
 

--- a/src/steps/trackReplaceStep.ts
+++ b/src/steps/trackReplaceStep.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Node as PMNode, Slice } from 'prosemirror-model'
+import { Fragment, Node as PMNode, Slice } from 'prosemirror-model'
 import type { EditorState, Transaction } from 'prosemirror-state'
 import { ReplaceStep, StepMap, StepResult } from 'prosemirror-transform'
 
@@ -96,9 +96,7 @@ export function trackReplaceStep(
       )
 
       if (isSplitStep(step, oldState.selection, tr.getMeta('uiEvent'))) {
-        fragment = setFragmentAsNodeSplit(fragment, attrs, oldState.schema)
-        // this for split mark we add
-        tr.mapping.appendMap(StepMap.offset(1))
+        fragment = setFragmentAsNodeSplit(newTr.doc.resolve(step.from), newTr, fragment, attrs)
       }
 
       // Since deleteAndMergeSplitBlockNodes modified the slice to not to contain any merged nodes,

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -130,7 +130,7 @@ export function trackTransaction(
       )
       const stepResult = newTr.maybeStep(newStep)
 
-      let [steps, startPos] = trackReplaceStep(step, oldState, newTr, emptyAttrs, stepResult, tr.docs[i])
+      let [steps, startPos] = trackReplaceStep(step, oldState, newTr, emptyAttrs, stepResult, tr.docs[i], tr)
 
       if (steps.length === 1) {
         const step: any = steps[0] // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -166,7 +166,7 @@ export function trackTransaction(
         newTr.setSelection(near)
       }
     } else if (step instanceof ReplaceAroundStep) {
-      let steps = trackReplaceAroundStep(step, oldState, tr, newTr, emptyAttrs)
+      let steps = trackReplaceAroundStep(step, oldState, tr, newTr, emptyAttrs, tr.docs[i])
       const deleted = steps.filter((s) => s.type !== 'insert-slice')
       const inserted = steps.filter((s) => s.type === 'insert-slice') as InsertSliceStep[]
       log.info('INSERT STEPS: ', inserted)

--- a/src/types/change.ts
+++ b/src/types/change.ts
@@ -17,7 +17,8 @@ export enum CHANGE_OPERATION {
   insert = 'insert',
   delete = 'delete',
   set_node_attributes = 'set_attrs',
-  // wrap_with_node = 'wrap_with_node',
+  node_split = 'node_split',
+  wrap_with_node = 'wrap_with_node',
   // unwrap_from_node = 'unwrap_from_node',
   // add_mark = 'add_mark',
   // remove_mark = 'remove_mark',
@@ -41,7 +42,17 @@ export type UpdateAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
   operation: CHANGE_OPERATION.set_node_attributes
   oldAttrs: Record<string, any>
 }
-export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs
+
+export type WrapAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
+  operation: CHANGE_OPERATION.wrap_with_node
+}
+
+export type NodeSplitAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
+  operation: CHANGE_OPERATION.node_split
+  splitMarkerId: string
+}
+
+export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs | WrapAttrs | NodeSplitAttrs
 
 type Change = {
   id: string

--- a/src/types/change.ts
+++ b/src/types/change.ts
@@ -84,10 +84,19 @@ export type WrapChange = Change & {
   type: 'wrap-change'
   wrapperNode: string
 }
+export type SplitSourceChange = Change & {
+  type: 'split-source'
+}
 export type MarkChange = Change & {
   type: 'mark-change'
 }
-export type TrackedChange = TextChange | NodeChange | NodeAttrChange | WrapChange | MarkChange
+export type TrackedChange =
+  | TextChange
+  | NodeChange
+  | NodeAttrChange
+  | WrapChange
+  | SplitSourceChange
+  | MarkChange
 export type PartialChange<T extends TrackedChange> = Omit<T, 'dataTracked'> & {
   dataTracked: Partial<TrackedAttrs>
 }

--- a/src/types/change.ts
+++ b/src/types/change.ts
@@ -17,9 +17,9 @@ export enum CHANGE_OPERATION {
   insert = 'insert',
   delete = 'delete',
   set_node_attributes = 'set_attrs',
-  node_split = 'node_split',
-  split_source = 'split_source',
   wrap_with_node = 'wrap_with_node',
+  node_split = 'node_split',
+  reference = 'reference',
   // unwrap_from_node = 'unwrap_from_node',
   // add_mark = 'add_mark',
   // remove_mark = 'remove_mark',
@@ -52,12 +52,12 @@ export type NodeSplitAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
   operation: CHANGE_OPERATION.node_split
 }
 
-export type SplitSourceAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
-  operation: CHANGE_OPERATION.split_source
+export type ReferenceAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
+  operation: CHANGE_OPERATION.reference
   referenceId: string
 }
 
-export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs | WrapAttrs | NodeSplitAttrs | SplitSourceAttrs
+export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs | WrapAttrs | NodeSplitAttrs | ReferenceAttrs
 
 type Change = {
   id: string
@@ -84,8 +84,8 @@ export type WrapChange = Change & {
   type: 'wrap-change'
   wrapperNode: string
 }
-export type SplitSourceChange = Change & {
-  type: 'split-source'
+export type ReferenceChange = Change & {
+  type: 'reference-change'
 }
 export type MarkChange = Change & {
   type: 'mark-change'
@@ -95,7 +95,7 @@ export type TrackedChange =
   | NodeChange
   | NodeAttrChange
   | WrapChange
-  | SplitSourceChange
+  | ReferenceChange
   | MarkChange
 export type PartialChange<T extends TrackedChange> = Omit<T, 'dataTracked'> & {
   dataTracked: Partial<TrackedAttrs>

--- a/src/types/change.ts
+++ b/src/types/change.ts
@@ -18,6 +18,7 @@ export enum CHANGE_OPERATION {
   delete = 'delete',
   set_node_attributes = 'set_attrs',
   node_split = 'node_split',
+  split_source = 'split_source',
   wrap_with_node = 'wrap_with_node',
   // unwrap_from_node = 'unwrap_from_node',
   // add_mark = 'add_mark',
@@ -49,10 +50,14 @@ export type WrapAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
 
 export type NodeSplitAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
   operation: CHANGE_OPERATION.node_split
-  splitMarkerId: string
 }
 
-export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs | WrapAttrs | NodeSplitAttrs
+export type SplitSourceAttrs = Omit<InsertDeleteAttrs, 'operation'> & {
+  operation: CHANGE_OPERATION.split_source
+  referenceId: string
+}
+
+export type TrackedAttrs = InsertDeleteAttrs | UpdateAttrs | WrapAttrs | NodeSplitAttrs | SplitSourceAttrs
 
 type Change = {
   id: string

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -45,8 +45,8 @@ export type NewUpdateAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
 export type NewSplitNodeAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
   operation: CHANGE_OPERATION.node_split
 }
-export type NewSplitSourceAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
-  operation: CHANGE_OPERATION.split_source
+export type NewReferenceAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
+  operation: CHANGE_OPERATION.reference
   referenceId: string
 }
 export type NewTrackedAttrs = NewInsertAttrs | NewDeleteAttrs | NewUpdateAttrs

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -33,7 +33,7 @@ export interface TrackChangesState {
 
 export type NewEmptyAttrs = Omit<TrackedAttrs, 'id' | 'operation'>
 export type NewInsertAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
-  operation: CHANGE_OPERATION.insert
+  operation: CHANGE_OPERATION.insert | CHANGE_OPERATION.wrap_with_node
 }
 export type NewDeleteAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
   operation: CHANGE_OPERATION.delete
@@ -41,6 +41,10 @@ export type NewDeleteAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
 export type NewUpdateAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
   operation: CHANGE_OPERATION.set_node_attributes
   oldAttrs: Record<string, any>
+}
+export type NewSplitNodeAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
+  operation: CHANGE_OPERATION.node_split
+  splitMarkerId?: string
 }
 export type NewTrackedAttrs = NewInsertAttrs | NewDeleteAttrs | NewUpdateAttrs
 

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -44,7 +44,10 @@ export type NewUpdateAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
 }
 export type NewSplitNodeAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
   operation: CHANGE_OPERATION.node_split
-  splitMarkerId?: string
+}
+export type NewSplitSourceAttrs = Omit<TrackedAttrs, 'id' | 'operation'> & {
+  operation: CHANGE_OPERATION.split_source
+  referenceId: string
 }
 export type NewTrackedAttrs = NewInsertAttrs | NewDeleteAttrs | NewUpdateAttrs
 

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -22,8 +22,8 @@ import {
   NewDeleteAttrs,
   NewEmptyAttrs,
   NewInsertAttrs,
+  NewReferenceAttrs,
   NewSplitNodeAttrs,
-  NewSplitSourceAttrs,
   NewUpdateAttrs,
 } from '../types/track'
 
@@ -48,10 +48,10 @@ export function createNewSplitAttrs(attrs: NewEmptyAttrs): NewSplitNodeAttrs {
   }
 }
 
-export function createNewSplitSourceAttrs(attrs: NewEmptyAttrs, id: string): NewSplitSourceAttrs {
+export function createNewSplitSourceAttrs(attrs: NewEmptyAttrs, id: string): NewReferenceAttrs {
   return {
     ...attrs,
-    operation: CHANGE_OPERATION.split_source,
+    operation: CHANGE_OPERATION.reference,
     referenceId: id,
   }
 }

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -23,6 +23,7 @@ import {
   NewEmptyAttrs,
   NewInsertAttrs,
   NewSplitNodeAttrs,
+  NewSplitSourceAttrs,
   NewUpdateAttrs,
 } from '../types/track'
 
@@ -44,6 +45,14 @@ export function createNewSplitAttrs(attrs: NewEmptyAttrs): NewSplitNodeAttrs {
   return {
     ...attrs,
     operation: CHANGE_OPERATION.node_split,
+  }
+}
+
+export function createNewSplitSourceAttrs(attrs: NewEmptyAttrs, id: string): NewSplitSourceAttrs {
+  return {
+    ...attrs,
+    operation: CHANGE_OPERATION.split_source,
+    referenceId: id,
   }
 }
 

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -84,13 +84,14 @@ export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: st
     return false
   }
 
+  const {
+    $anchor: { parentOffset: startOffset },
+    $head: { parentOffset: endOffset },
+    $from,
+  } = selection
+  const parentSize = $from.node().content.size
+
   if (uiEvent === 'paste') {
-    const {
-      $anchor: { parentOffset: startOffset },
-      $head: { parentOffset: endOffset },
-      $from,
-    } = selection
-    const parentSize = $from.node().content.size
     // paste of content on the side of selection will not be considered as node split
     return !(
       (startOffset === 0 && endOffset === 0) ||
@@ -104,9 +105,12 @@ export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: st
     openEnd,
   } = slice
 
-  // @ts-ignore
-  if (window.event.type === 'keydown' && firstChild?.type.name === 'list_item') {
-    return lastChild?.type.name === 'list_item'
+  if (
+    // @ts-ignore
+    (window.event?.code === 'Enter' || window.event?.code === 'NumpadEnter') &&
+    firstChild?.type.name === 'list_item'
+  ) {
+    return !(parentSize === startOffset && parentSize === endOffset) && lastChild?.type.name === 'list_item'
   }
 
   return (

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Mark } from 'prosemirror-model'
+import { Fragment } from 'prosemirror-model'
 import { Selection, TextSelection } from 'prosemirror-state'
-import { ReplaceStep } from 'prosemirror-transform'
+import { ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
 import { CHANGE_OPERATION } from '../types/change'
 import {
@@ -98,3 +98,6 @@ export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: st
     lastChild!.inlineContent
   )
 }
+
+export const isWrapStep = (step: ReplaceAroundStep, content: Fragment) =>
+  step.from === step.gapFrom && step.to === step.gapTo && content.size === 0

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -104,6 +104,11 @@ export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: st
     openEnd,
   } = slice
 
+  // @ts-ignore
+  if (window.event.type === 'keydown' && firstChild?.type.name === 'list_item') {
+    return lastChild?.type.name === 'list_item'
+  }
+
   return (
     openStart === openEnd &&
     firstChild!.type === lastChild!.type &&

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -76,7 +76,11 @@ export function createNewUpdateAttrs(attrs: NewEmptyAttrs, oldAttrs: Record<stri
 export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: string) => {
   const { from, to, slice } = step
 
-  if (from !== to || slice.content.childCount < 2) {
+  if (
+    from !== to ||
+    slice.content.childCount < 2 ||
+    (slice.content.firstChild?.isInline && slice.content.lastChild?.isInline)
+  ) {
     return false
   }
 
@@ -108,5 +112,8 @@ export const isSplitStep = (step: ReplaceStep, selection: Selection, uiEvent: st
   )
 }
 
-export const isWrapStep = (step: ReplaceAroundStep, content: Fragment) =>
-  step.from === step.gapFrom && step.to === step.gapTo && content.size === 0
+export const isWrapStep = (step: ReplaceAroundStep) =>
+  step.from === step.gapFrom &&
+  step.to === step.gapTo &&
+  step.slice.openStart === 0 &&
+  step.slice.openEnd === 0

--- a/test/__fixtures__/list.json
+++ b/test/__fixtures__/list.json
@@ -159,6 +159,54 @@
     {
       "type": "paragraph",
       "attrs": {
+        "id": "MPParagraphElement:6B541017-DC6A-44A7-A67A-DD599D171E64",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "1",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
+        "id": "MPParagraphElement:C6F0DA83-246A-460F-8D43-1E56C9027FFE",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "2",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
+        "id": "MPParagraphElement:9CFDF5FE-66D6-4726-A914-074D57B2DADB",
+        "comments": null,
+        "dataTracked": null,
+        "placeholder": "",
+        "paragraphStyle": ""
+      },
+      "content": [
+        {
+          "text": "3",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
         "id": "MPParagraphElement:AB306236-74E2-4FE5-976D-7A1B6CD94D5F",
         "comments": [],
         "dataTracked": null,

--- a/test/apply-changes/apply-changes.test.ts
+++ b/test/apply-changes/apply-changes.test.ts
@@ -16,6 +16,7 @@
 /// <reference types="@types/jest" />;
 import { schema as manuscriptSchema } from '@manuscripts/transform'
 import { promises as fs } from 'fs'
+import { baseKeymap } from 'prosemirror-commands'
 
 import { CHANGE_STATUS, ChangeSet, trackChangesPluginKey, trackCommands } from '../../src'
 import { log } from '../../src/utils/logger'
@@ -171,5 +172,26 @@ describe('apply-changes.test', () => {
 
     expect(tester.toJSON()).toEqual(insertAccept[1])
     expect(uuidv4Mock.mock.calls.length).toBe(26)
+  })
+
+  test('should delete reference change', async () => {
+    const tester = setupEditor({
+      doc: docs.paragraph,
+    })
+      .selectText(7)
+      .cmd(baseKeymap['Enter'])
+
+    tester.cmd((state, dispatch) => {
+      const nodeSplitChange = tester
+        .trackState()
+        ?.changeSet?.pending.find((change) => change.dataTracked.operation === 'node_split')
+      if (nodeSplitChange) {
+        trackCommands.setChangeStatuses(CHANGE_STATUS.rejected, [nodeSplitChange.id])(state, dispatch)
+      }
+    })
+
+    tester.cmd(trackCommands.applyAndRemoveChanges())
+
+    expect(tester.trackState()?.changeSet.changes.length).toEqual(0)
   })
 })

--- a/test/nodes/block-node-attr-update.json
+++ b/test/nodes/block-node-attr-update.json
@@ -82,7 +82,7 @@
                 "TeXRepresentation": "1+1=2",
                 "dataTracked": [
                   {
-                    "id": "MOCK-ID-6",
+                    "id": "MOCK-ID-8",
                     "oldAttrs": {
                       "id": "",
                       "class": "equation",

--- a/test/nodes/nodes.test.ts
+++ b/test/nodes/nodes.test.ts
@@ -231,6 +231,19 @@ describe('nodes.test', () => {
     expect(log.error).toHaveBeenCalledTimes(0)
   })
 
+  // TODO:: this example of sending multiple steps in one transaction for the same node. it's going to be a reference to fix it later
+  test.skip('should track inserting list with with multiple paragraph selected', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(37, 44)
+      .wrapInList(schema.nodes.bullet_list)
+
+    expect(tester.trackState()?.changeSet.hasInconsistentData).toEqual(false)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
   test.skip('should track node attribute updates', async () => {
     const tester = setupEditor({
       doc: docs.paragraph,

--- a/test/nodes/nodes.test.ts
+++ b/test/nodes/nodes.test.ts
@@ -16,6 +16,7 @@
 /// <reference types="@types/jest" />;
 import { schema as manuscriptSchema } from '@manuscripts/transform'
 import { promises as fs } from 'fs'
+import { baseKeymap } from 'prosemirror-commands'
 import { NodeSelection } from 'prosemirror-state'
 
 import { CHANGE_STATUS, ChangeSet, NodeAttrChange, trackChangesPluginKey, trackCommands } from '../../src'
@@ -265,6 +266,98 @@ describe('nodes.test', () => {
 
     expect(tester.toJSON()).toEqual(blockNodeAttrUpdate)
     expect(uuidv4Mock.mock.calls.length).toBe(1)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('should track node split', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(60)
+      .cmd(baseKeymap['Enter'])
+
+    const changeSet = tester.trackState()?.changeSet
+    expect(changeSet?.rejected.find((change) => change.type === 'reference-change')).not.toBeUndefined()
+    expect(
+      changeSet?.pending.find((change) => change.dataTracked.operation === 'node_split')
+    ).not.toBeUndefined()
+
+    expect(tester.trackState()?.changeSet?.hasInconsistentData).toEqual(false)
+    expect(uuidv4Mock.mock.calls.length).toBe(4)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('should return back node split content on rejection to the donor node', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(60)
+      .cmd(baseKeymap['Enter'])
+
+    const nodeSplitChange = tester
+      .trackState()
+      ?.changeSet?.pending.find((change) => change.dataTracked.operation === 'node_split')
+    expect(nodeSplitChange).not.toBeUndefined()
+
+    tester.cmd((state, dispatch) => {
+      if (nodeSplitChange) {
+        trackCommands.setChangeStatuses(CHANGE_STATUS.rejected, [nodeSplitChange.id])(state, dispatch)
+      }
+    })
+
+    expect(tester.view.state.doc.nodeAt(45)?.nodeSize).toEqual(262)
+
+    expect(tester.trackState()?.changeSet?.hasInconsistentData).toEqual(false)
+    expect(uuidv4Mock.mock.calls.length).toBe(4)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('should update change reference for the second node split change on rejection', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(60)
+      .cmd(baseKeymap['Enter'])
+      .selectText(74)
+      .cmd(baseKeymap['Enter'])
+
+    tester.cmd((state, dispatch) => {
+      // reject first split
+      const nodeSplitChange = tester.trackState()?.changeSet.changeTree.find((change) => change.from === 61)
+      if (nodeSplitChange) {
+        trackCommands.setChangeStatuses(CHANGE_STATUS.rejected, [nodeSplitChange.id])(state, dispatch)
+      }
+    })
+
+    const changes = tester.trackState()?.changeSet.changes
+    const nodeSplitChange = changes?.find((change) => change.dataTracked.operation === 'node_split')
+    const referenceChange = changes?.find((change) => change.type === 'reference-change')
+    expect((referenceChange?.dataTracked as any).referenceId).toEqual(nodeSplitChange?.id)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('should revert node delete change on rejecting node split change', async () => {
+    const tester = setupEditor({
+      doc: docs.paragraph,
+    })
+      .selectText(7)
+      .cmd(baseKeymap['Enter'])
+      .delete(0, 7)
+
+    tester.cmd((state, dispatch) => {
+      const nodeSplitChange = tester
+        .trackState()
+        ?.changeSet.changes.find((change) => change.dataTracked.operation === 'node_split')
+      if (nodeSplitChange) {
+        trackCommands.setChangeStatuses(CHANGE_STATUS.rejected, [nodeSplitChange.id])(state, dispatch)
+      }
+    })
+
+    expect(tester.trackState()?.changeSet.bothNodeChanges.length).toEqual(0)
     expect(log.warn).toHaveBeenCalledTimes(0)
     expect(log.error).toHaveBeenCalledTimes(0)
   })

--- a/test/nodes/wrap-with-link.json
+++ b/test/nodes/wrap-with-link.json
@@ -24,7 +24,7 @@
                     "updatedAt": 1577836800000,
                     "statusUpdateAt": 0,
                     "status": "pending",
-                    "operation": "insert"
+                    "operation": "wrap_with_node"
                   }
                 ]
               },
@@ -74,7 +74,7 @@
                     "updatedAt": 1577836800000,
                     "statusUpdateAt": 0,
                     "status": "pending",
-                    "operation": "insert"
+                    "operation": "wrap_with_node"
                   }
                 ]
               },

--- a/test/replace-around-steps/replace-around-steps.json
+++ b/test/replace-around-steps/replace-around-steps.json
@@ -81,7 +81,7 @@
                 "updatedAt": 1577836800000,
                 "statusUpdateAt": 0,
                 "status": "pending",
-                "operation": "insert"
+                "operation": "wrap_with_node"
               }
             ]
           },

--- a/test/replace-around-steps/replace-around-steps.test.ts
+++ b/test/replace-around-steps/replace-around-steps.test.ts
@@ -18,7 +18,7 @@ import { promises as fs } from 'fs'
 import { Fragment, Slice } from 'prosemirror-model'
 import { liftTarget } from 'prosemirror-transform'
 
-import { trackCommands } from '../../src'
+import { CHANGE_STATUS, ChangeSet, trackChangesPluginKey, trackCommands } from '../../src'
 import { log } from '../../src/utils/logger'
 import docs from '../__fixtures__/docs'
 import { schema } from '../utils/schema'
@@ -160,5 +160,31 @@ describe('replace-around-steps.test', () => {
 
     // TODO:: assert will be based on what we decided to do with Replaced Around step for open end slice,
     //        track it as insert/delete!
+  })
+
+  test('should return back wrapped content on rejection', async () => {
+    const tester = setupEditor({
+      doc: docs.list,
+    })
+      .selectText(37, 44)
+      .wrapIn(schema.nodes.bullet_list)
+
+    const wrapWithNodeChange = tester
+      .trackState()
+      ?.changeSet.pending.find((change) => change.dataTracked.operation === 'wrap_with_node')
+    expect(wrapWithNodeChange).not.toBeUndefined()
+
+    tester.cmd((state, dispatch) => {
+      if (wrapWithNodeChange) {
+        trackCommands.setChangeStatuses(CHANGE_STATUS.rejected, [wrapWithNodeChange.id])(state, dispatch)
+      }
+    })
+
+    expect(tester.view.state.doc.slice(37, 44).content.textBetween(0, 9)).toEqual('123')
+
+    expect(tester.trackState()?.changeSet?.hasInconsistentData).toEqual(false)
+    expect(uuidv4Mock.mock.calls.length).toBe(2)
+    expect(log.warn).toHaveBeenCalledTimes(0)
+    expect(log.error).toHaveBeenCalledTimes(0)
   })
 })

--- a/test/utils/PMTestChain.ts
+++ b/test/utils/PMTestChain.ts
@@ -17,7 +17,7 @@ import { wrapIn } from 'prosemirror-commands'
 // import {lift, joinUp, selectParentNode, wrapIn, setBlockType} from "prosemirror-commands"
 import { exampleSetup } from 'prosemirror-example-setup'
 import { Mark, Node as PMNode, NodeRange, NodeType, Schema, Slice } from 'prosemirror-model'
-import { liftListItem, sinkListItem } from 'prosemirror-schema-list'
+import { liftListItem, sinkListItem, wrapInList } from 'prosemirror-schema-list'
 import { EditorState, Plugin, TextSelection, Transaction } from 'prosemirror-state'
 import { findWrapping } from 'prosemirror-transform'
 import { EditorView } from 'prosemirror-view'
@@ -186,6 +186,11 @@ export class ProsemirrorTestChain {
         wrapping = findWrapping(range, nodeType, attrs)
       wrapping && dispatch(state.tr.wrap(range, wrapping))
     })
+    return this
+  }
+
+  wrapInList(nodeType: NodeType) {
+    this.cmd(wrapInList(nodeType))
     return this
   }
 


### PR DESCRIPTION
This PR will detect the split and wrapping of node, and on rejection will return original content back so we don't lose that content when applying changes. 

To know for node split where it was before, we add a text marker to track that location and that marker will be deleted once it's rejected or applied change