### PR TITLE
Skip remapping if the operation is delete - LEAN-3898

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.17",
+  "version": "1.7.18-LEAN-3898.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/steps/trackTransaction.ts
+++ b/src/steps/trackTransaction.ts
@@ -111,6 +111,7 @@ export function trackTransaction(
         continue
       }
       const invertedStep = step.invert(tr.docs[i])
+      const isDelete = step.from !== step.to && step.slice.content.size < invertedStep.slice.content.size
 
       const thisStepMapping = tr.mapping.slice(i + 1)
       /* 
@@ -128,7 +129,7 @@ export function trackTransaction(
         thisStepMapping.map(invertedStep.to),
         invertedStep.slice
       )
-      const stepResult = newTr.maybeStep(newStep)
+      const stepResult = newTr.maybeStep(isDelete ? invertedStep : newStep)
 
       let [steps, startPos] = trackReplaceStep(step, oldState, newTr, emptyAttrs, stepResult, tr.docs[i])
 
@@ -140,8 +141,10 @@ export function trackTransaction(
         }
       }
 
-      startPos = thisStepMapping.map(startPos)
-      steps = mapChangeSteps(steps, thisStepMapping)
+      if (!isDelete) {
+        startPos = thisStepMapping.map(startPos)
+        steps = mapChangeSteps(steps, thisStepMapping)
+      }
 
       log.info('CHANGES: ', steps)
       // deleted and merged really...


### PR DESCRIPTION
Problem: When applying several delete steps on the same transaction, they are not tracked correctly. This issue appears after the changes done in https://github.com/Atypon-OpenSource/manuscripts-body-editor/pull/334 (cc: @fwaisi)

I believe that in the case of deleting content, remapping will not be needed because we are not actually deleting it but rather leaving the content with a line through it. Therefore, the document structure has not actually been changed.