### PR TITLE
LEAN-4097 check empty content before merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.8.2-LEAN-4097.0",
+  "version": "1.8.2",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.8.1",
+  "version": "1.8.2-LEAN-4097.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/mutate/deleteAndMergeSplitNodes.ts
+++ b/src/mutate/deleteAndMergeSplitNodes.ts
@@ -130,12 +130,12 @@ export function deleteAndMergeSplitNodes(
         // Then we only have to ensure the depth is at the right level, so say a fully open blockquote insert will
         // be merged at the lowest, paragraph level, instead of blockquote level.
         const mergeStartNode =
-          endTokenDeleted && openStart > 0 && depth === openStart && mergeContent !== undefined
+          endTokenDeleted && openStart > 0 && depth === openStart && mergeContent && mergeContent.size
         // Same as above, merge nodes manually if there exists an open slice with mergeable content.
         // Compared to deleting an end token however, the merged block node is set as deleted. This is due to
         // ProseMirror node semantics as start tokens are considered to contain the actual node itself.
         const mergeEndNode =
-          startTokenDeleted && openEnd > 0 && depth === openEnd && mergeContent !== undefined
+          startTokenDeleted && openEnd > 0 && depth === openEnd && mergeContent && mergeContent.size
 
         if (mergeStartNode || mergeEndNode) {
           // Just as a fun fact that I found out while debugging this. Inserting text at paragraph position wraps


### PR DESCRIPTION
I'm not sure what the purpose of the depth check is to be honest, but it's causing an issue when pressing enter at the end of a paragraph when it's not in a section. Either way, the plugin is generating a "merge-fragment" step even though the content is actually empty.