### PR TITLE
Retain old dataTracked if there are no new changes - LEAN-4168

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.8.4",
+  "version": "1.8.5-LEAN-4168.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.8.5-LEAN-4168.0",
+  "version": "1.8.5",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/change-steps/processChangeSteps.ts
+++ b/src/change-steps/processChangeSteps.ts
@@ -173,12 +173,16 @@ export function processChangeSteps(
         ) {
           newDataTracked.push(newUpdate)
         }
+
+        // Retain old dataTracked if there are no new changes
+        const finalDataTracked = newDataTracked.length > 0 ? newDataTracked : oldDataTracked
+
         newTr.setNodeMarkup(
           mapping.map(c.pos),
           undefined,
           {
             ...c.newAttrs,
-            dataTracked: newDataTracked.length > 0 ? newDataTracked : null,
+            dataTracked: finalDataTracked.length > 0 ? finalDataTracked : null,
           },
           c.node.marks
         )


### PR DESCRIPTION
**Problem**: Clicking the save button a second time in the Author and References modals (without making any new changes) clears the `dataTracked` attribute.

**Solution**: Retain the old `dataTracked` value if there are no new changes.