### PR TITLE
LEAN-4242: LW-FY25-Q3-S4&5: Unreferenced note remained after rejectin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.9.2",
+  "version": "1.9.3-LEAN-4242.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.9.3-LEAN-4242.0",
+  "version": "1.9.3",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/changes/applyChanges.ts
+++ b/src/changes/applyChanges.ts
@@ -64,8 +64,11 @@ export function applyAcceptedRejectedChanges(
     // or were already deleted by an applied block delete
     const { pos: from, deleted } = deleteMap.mapResult(change.from)
     const node = tr.doc.nodeAt(from)
-    const noChangeNeeded = deleted || !ChangeSet.shouldDeleteChange(change)
-
+    const noChangeNeeded = !ChangeSet.shouldDeleteChange(change)
+    if (deleted) {
+      // Skip if the change was already deleted
+      return
+    }
     if (!node) {
       !deleted && log.warn('no node found to update for change', change)
       return


### PR DESCRIPTION
**Problem**
The issue reported by QA in this ticket is not limited to the specific scenario they described (un-referencing a note and then rejecting it). Instead, it applies more broadly to regular footnotes and references as well. The issue is reproducible when rejecting suggestions sequentially from top to bottom.

The problem arises because the first footnote node, which has no nodeBefore is deleted . However, after the node is deleted, instead of updating the deleteMap, the updateChangeChildrenAttributes logic is executed. This happens because the check for whether the change is deleted is incorrectly tied to the noChangeNeeded condition.

Since a deleted change requires no further actions, including updating attributes, having this check as part of noChangeNeeded is unnecessary and causes the issue.

I have Conducted regression testing for all node types, including footnotes, references, and other block-level and inline nodes and Verified that the changes work as expected across all scenarios.