### PR TITLE
LEAN-4372 LW-FY25-Q4-S2: Inserting a Link in Pending Text Creates an …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.5",
+  "version": "1.10.4",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.5-LEAN-4372.0",
+  "version": "1.10.5-LEAN-4372.1",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@manuscripts/eslint-config": "^0.5.1",
-    "@manuscripts/transform": "3.0.45",
+    "@manuscripts/transform": "3.0.48",
     "@types/debug": "^4.1.7",
     "@types/jest": "27.5.1",
     "@types/node": "^18.7.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.5-LEAN-4372.1",
+  "version": "1.10.5",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.4",
+  "version": "1.10.5-LEAN-4372.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -220,8 +220,10 @@ export class ChangeSet {
       c.type === 'text-change' || (c.type === 'node-change' && c.node.isInline)
     const hasMatchingOperation = (c1: TrackedChange, c2: TrackedChange) =>
       c1.dataTracked.operation === c2.dataTracked.operation ||
-      c1.dataTracked.operation === 'wrap_with_node' ||
-      c2.dataTracked.operation === 'wrap_with_node'
+      (c1.dataTracked.operation === 'wrap_with_node' &&
+        (c2.dataTracked.operation === 'insert' || c2.dataTracked.operation === 'set_attrs')) ||
+      (c2.dataTracked.operation === 'wrap_with_node' &&
+        (c1.dataTracked.operation === 'insert' || c1.dataTracked.operation === 'set_attrs'))
 
     return (
       isInline(change) &&

--- a/src/ChangeSet.ts
+++ b/src/ChangeSet.ts
@@ -218,12 +218,17 @@ export class ChangeSet {
     const nextChange = this.changeTree.at(index + 1)
     const isInline = (c: TrackedChange) =>
       c.type === 'text-change' || (c.type === 'node-change' && c.node.isInline)
+    const hasMatchingOperation = (c1: TrackedChange, c2: TrackedChange) =>
+      c1.dataTracked.operation === c2.dataTracked.operation ||
+      c1.dataTracked.operation === 'wrap_with_node' ||
+      c2.dataTracked.operation === 'wrap_with_node'
+
     return (
       isInline(change) &&
       nextChange &&
       isInline(nextChange) &&
       change.to === nextChange.from &&
-      change.dataTracked.operation === nextChange.dataTracked.operation
+      hasMatchingOperation(change, nextChange)
     )
   }
 

--- a/src/mutate/mergeTrackedMarks.ts
+++ b/src/mutate/mergeTrackedMarks.ts
@@ -18,6 +18,7 @@ import type { Transaction } from 'prosemirror-state'
 
 import { shouldMergeTrackedAttributes } from '../compute/nodeHelpers'
 import type { TrackedAttrs } from '../types/change'
+import { uuidv4 } from '../utils/uuidv4'
 
 /**
  * Merges tracked marks between text nodes at a position
@@ -55,6 +56,9 @@ export function mergeTrackedMarks(pos: number, doc: PMNode, newTr: Transaction, 
   }
   const fromStartOfMark = pos - nodeBefore.nodeSize
   const toEndOfMark = pos + nodeAfter.nodeSize
-
-  newTr.addMark(fromStartOfMark, toEndOfMark, leftMark.type.create({ ...leftMark.attrs, dataTracked }))
+  newTr.addMark(
+    fromStartOfMark,
+    toEndOfMark,
+    leftMark.type.create({ ...leftMark.attrs, dataTracked: [{ ...dataTracked, id: uuidv4() }] })
+  )
 }

--- a/src/mutate/mergeTrackedMarks.ts
+++ b/src/mutate/mergeTrackedMarks.ts
@@ -59,6 +59,6 @@ export function mergeTrackedMarks(pos: number, doc: PMNode, newTr: Transaction, 
   newTr.addMark(
     fromStartOfMark,
     toEndOfMark,
-    leftMark.type.create({ ...leftMark.attrs, dataTracked: [{ ...dataTracked, id: uuidv4() }] })
+    leftMark.type.create({ ...leftMark.attrs, dataTracked: { ...dataTracked, id: uuidv4() } })
   )
 }

--- a/src/mutate/mergeTrackedMarks.ts
+++ b/src/mutate/mergeTrackedMarks.ts
@@ -20,9 +20,11 @@ import { shouldMergeTrackedAttributes } from '../compute/nodeHelpers'
 import type { TrackedAttrs } from '../types/change'
 import { uuidv4 } from '../utils/uuidv4'
 
-
-const assignId = (attrs: Partial<TrackedAttrs>, leftDataTracked: Partial<TrackedAttrs>, rightDataTracked: Partial<TrackedAttrs>) => {
-
+const assignId = (
+  attrs: Partial<TrackedAttrs>,
+  leftDataTracked: Partial<TrackedAttrs>,
+  rightDataTracked: Partial<TrackedAttrs>
+) => {
   if (attrs.id === leftDataTracked.id || attrs.id === rightDataTracked.id) {
     return { ...attrs, id: uuidv4() }
   }
@@ -69,6 +71,9 @@ export function mergeTrackedMarks(pos: number, doc: PMNode, newTr: Transaction, 
   newTr.addMark(
     fromStartOfMark,
     toEndOfMark,
-    leftMark.type.create({ ...leftMark.attrs, dataTracked: assignId(dataTracked, leftDataTracked, rightDataTracked) })
+    leftMark.type.create({
+      ...leftMark.attrs,
+      dataTracked: assignId(dataTracked, leftDataTracked, rightDataTracked),
+    })
   )
 }

--- a/src/mutate/mergeTrackedMarks.ts
+++ b/src/mutate/mergeTrackedMarks.ts
@@ -20,6 +20,8 @@ import { shouldMergeTrackedAttributes } from '../compute/nodeHelpers'
 import type { TrackedAttrs } from '../types/change'
 import { uuidv4 } from '../utils/uuidv4'
 
+// Update the id of the mark to a new uuid if it is the same as the left or right mark, to avoid
+// conflicts when merging marks
 const assignId = (
   attrs: Partial<TrackedAttrs>,
   leftDataTracked: Partial<TrackedAttrs>,

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Fragment, Node as PMNode, Slice } from 'prosemirror-model'
+import { isLinkNode } from '@manuscripts/transform'
+import { Node as PMNode, Slice } from 'prosemirror-model'
 import type { EditorState, Transaction } from 'prosemirror-state'
-import { Mapping, ReplaceAroundStep } from 'prosemirror-transform'
+import { ReplaceAroundStep } from 'prosemirror-transform'
 
 import { TrackChangesAction } from '../actions'
-import { addTrackIdIfDoesntExist } from '../compute/nodeHelpers'
 import { setFragmentAsInserted, setFragmentAsWrapChange } from '../compute/setFragmentAsInserted'
 import { deleteAndMergeSplitNodes } from '../mutate/deleteAndMergeSplitNodes'
 import { ExposedSlice } from '../types/pm'
@@ -119,8 +119,7 @@ export function trackReplaceAroundStep(
   )
 
   let fragment
-
-  if (isWrapStep(step)) {
+  if (isWrapStep(step) && !isLinkNode(slice.content.firstChild)) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
   } else {
     fragment = setFragmentAsInserted(newSliceContent, trackUtils.createNewInsertAttrs(attrs), oldState.schema)

--- a/src/steps/trackReplaceAroundStep.ts
+++ b/src/steps/trackReplaceAroundStep.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { isLinkNode } from '@manuscripts/transform'
 import { Node as PMNode, Slice } from 'prosemirror-model'
 import type { EditorState, Transaction } from 'prosemirror-state'
 import { ReplaceAroundStep } from 'prosemirror-transform'
@@ -119,7 +118,7 @@ export function trackReplaceAroundStep(
   )
 
   let fragment
-  if (isWrapStep(step) && !isLinkNode(slice.content.firstChild)) {
+  if (isWrapStep(step)) {
     fragment = setFragmentAsWrapChange(newSliceContent, attrs, oldState.schema)
   } else {
     fragment = setFragmentAsInserted(newSliceContent, trackUtils.createNewInsertAttrs(attrs), oldState.schema)

--- a/test/__fixtures__/contributors-affiliation.json
+++ b/test/__fixtures__/contributors-affiliation.json
@@ -36,9 +36,7 @@
                   "email": "",
                   "contents": "",
                   "priority": 1,
-                  "affiliations": [
-                    "MPAffiliation:E8F4BC14-02AC-4150-8051-D0454EB3BDBC"
-                  ],
+                  "affiliations": ["MPAffiliation:E8F4BC14-02AC-4150-8051-D0454EB3BDBC"],
                   "bibliographicName": {
                     "_id": "MPBibliographicName:DF6D079F-BD5D-4BC7-9F82-2F35C590D8C1",
                     "given": "Wei Ming",
@@ -53,9 +51,7 @@
                 "statusUpdateAt": 1708932415886
               }
             ],
-            "affiliations": [
-              "MPAffiliation:E8F4BC14-02AC-4150-8051-D0454EB3BDBC"
-            ],
+            "affiliations": ["MPAffiliation:E8F4BC14-02AC-4150-8051-D0454EB3BDBC"],
             "ORCIDIdentifier": "",
             "isCorresponding": false,
             "bibliographicName": {
@@ -99,9 +95,7 @@
             "contents": "",
             "priority": 3,
             "dataTracked": null,
-            "affiliations": [
-              "MPAffiliation:E5DA0604-8C6E-4D68-9E48-B0E6E70E7332"
-            ],
+            "affiliations": ["MPAffiliation:E5DA0604-8C6E-4D68-9E48-B0E6E70E7332"],
             "bibliographicName": {
               "_id": "MPBibliographicName:EA68A19F-6CF7-458F-968C-BD176A77E3B5",
               "given": "Song Tian",

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,71 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@citation-js/core@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@citation-js/core/-/core-0.7.18.tgz#97ca07264a80e6873a1c0605aaffcbe7193d7397"
+  integrity sha512-EjLuZWA5156dIFGdF7OnyPyWFBW43B8Ckje6Sn/W2RFxHDu0oACvW4/6TNgWT80jhEA4bVFm7ahrZe9MJ2B2UQ==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+    fetch-ponyfill "^7.1.0"
+    sync-fetch "^0.4.1"
+
+"@citation-js/date@^0.5.0":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@citation-js/date/-/date-0.5.1.tgz#5d4e3746ce6a66b467c94071284de1c38e9a4987"
+  integrity sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw==
+
+"@citation-js/name@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@citation-js/name/-/name-0.4.2.tgz#8dc834b7e6c06998fc8d3b63632658754c94a875"
+  integrity sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==
+
+"@citation-js/plugin-bibtex@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-bibtex/-/plugin-bibtex-0.7.18.tgz#4770f0d19985a064e887c6062cd85b7f0ad21e16"
+  integrity sha512-TdsZSMpgpfcx2NMPu0KiulEoecllwT5EtRUzAJl2pDsdPD1tUqqbyj/NBi0l8fwNy1r7WwAqSFGiqGPjQWpFdg==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+    moo "^0.5.1"
+
+"@citation-js/plugin-csl@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-csl/-/plugin-csl-0.7.18.tgz#309dcc1501097c53e394ac346b0641a1209c628a"
+  integrity sha512-cJcOdEZurmtIxNj0d4cOERHpVQJB/mN3YPSDNqfI/xTFRN3bWDpFAsaqubPtMO2ZPpoDS+ZGIP1kggbwCfMmlA==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    citeproc "^2.4.6"
+
+"@citation-js/plugin-doi@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-doi/-/plugin-doi-0.7.18.tgz#deae9bfde5aa394e027c3152b11e2ff26b732afc"
+  integrity sha512-7ccmhfJJSDUhUqpWxesLAp3m1P5dhnZ4QNMctwJnU41T9vKGF7MXPKqMONSvL5JDZ7o7iWQTj2BFhSmh0euQxw==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+
+"@citation-js/plugin-enw@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-enw/-/plugin-enw-0.3.0.tgz#a5c6d6bbb335a876d50e349680d85c436e21abac"
+  integrity sha512-TT1GrWCuLNC9N2uXXjFfLO/0tBwgcO2YQIJuUrcFElV85hj9uvxpACQopUb9WXoyWwSmHsyG9dFWiztJrwaURg==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+
+"@citation-js/plugin-pubmed@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-pubmed/-/plugin-pubmed-0.3.0.tgz#8245b3a18c334e22483f1091b0bbc7492e07677e"
+  integrity sha512-E3l83VP5UnTh6lLJaTaNBIkNgIx3U6IjDNf7j5l4geBOaOwDIhkl9X+Ss33/MMNEIMNDsBoodoMJTZ8Cq+C/ug==
+
+"@citation-js/plugin-ris@^0.7.18":
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-ris/-/plugin-ris-0.7.18.tgz#2d29a1bee96543cfadc8fb35a9b9a6e9e18da8c6"
+  integrity sha512-aHd8isGGxz6P63UjyTR4RfX1alqxu8PQLWeoUBcnTMAPmyn6qzJfdB+iZEFA8HyL4g3I33n431zL/0BV8XlJiw==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -606,21 +671,28 @@
     deepmerge "^4.3.1"
     uuid "^9.0.0"
 
-"@manuscripts/library@1.3.11":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@manuscripts/library/-/library-1.3.11.tgz#76d6c8170c849aa6a010fcd504e79e494dd49ea4"
-  integrity sha512-FaTKYDXNvps1twUiyHOwbb0phgK44cqq5in4XTEP/wH5T24h6mQkFyxaaSSwxtYImVH7zvICxXS0XTI5d56jkg==
+"@manuscripts/library@1.3.12":
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/@manuscripts/library/-/library-1.3.12.tgz#c4ded98fe1847a3742ad885753b6265111bad061"
+  integrity sha512-1DihbNtCQrkG+clJJ0hS9FIG8w03XOYjNJsDVE+9zg2YyoEClhUSmj7UxyLcaawpZr5IxuDC1CeyG46jPnsHCg==
   dependencies:
+    "@citation-js/core" "^0.7.18"
+    "@citation-js/plugin-bibtex" "^0.7.18"
+    "@citation-js/plugin-csl" "^0.7.18"
+    "@citation-js/plugin-doi" "^0.7.18"
+    "@citation-js/plugin-enw" "^0.3.0"
+    "@citation-js/plugin-pubmed" "^0.3.0"
+    "@citation-js/plugin-ris" "^0.7.18"
     "@manuscripts/json-schema" "2.2.10"
     citeproc "^2.4.62"
 
-"@manuscripts/transform@3.0.45":
-  version "3.0.45"
-  resolved "https://registry.yarnpkg.com/@manuscripts/transform/-/transform-3.0.45.tgz#9706c773b863293fb0b8fe353c628f8afa1d4ce1"
-  integrity sha512-Jsr+Zw3RBdPr0KnbS/iQLW23wCgHsfaZGDTYm20QlLHpVdD26f2ZKLLxTIEcR4HYby9R3m1DB108WrDQNf8Q/g==
+"@manuscripts/transform@3.0.48":
+  version "3.0.48"
+  resolved "https://registry.yarnpkg.com/@manuscripts/transform/-/transform-3.0.48.tgz#ef0786fb54133bd521c51fe300f5c09d60ab8ae9"
+  integrity sha512-A23xO6ybhE9ek9Le6lNR6re6faAXQP2GirPx8gvJUxICn6FP8HVg2RWb044jzoJ753IGCto4qMggGFHj57o+YQ==
   dependencies:
     "@manuscripts/json-schema" "2.2.11"
-    "@manuscripts/library" "1.3.11"
+    "@manuscripts/library" "1.3.12"
     debug "^4.3.4"
     jszip "^3.10.1"
     lodash "^4.17.21"
@@ -1269,6 +1341,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 big-integer@^1.6.44:
   version "1.6.52"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
@@ -1329,6 +1406,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bundle-name@^3.0.0:
   version "3.0.0"
@@ -1433,7 +1518,7 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.1.tgz#708a6cdae38915d597afdf3b145f2f8e1ff55f3f"
   integrity sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==
 
-citeproc@^2.4.62:
+citeproc@^2.4.6, citeproc@^2.4.62:
   version "2.4.63"
   resolved "https://registry.yarnpkg.com/citeproc/-/citeproc-2.4.63.tgz#de6d30646e264f96b39cedb526f231abe1a5a718"
   integrity sha512-68F95Bp4UbgZU/DBUGQn0qV3HDZLCdI9+Bb2ByrTaNJDL5VEm9LqaiNaxljsvoaExSLEXe1/r6n2Z06SCzW3/Q==
@@ -2269,6 +2354,13 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-ponyfill@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz#4266ed48b4e64663a50ab7f7fcb8e76f990526d0"
+  integrity sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==
+  dependencies:
+    node-fetch "~2.6.1"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -2621,6 +2713,11 @@ iconv-lite@0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.0:
   version "5.3.0"
@@ -4204,6 +4301,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+moo@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -4233,6 +4335,20 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@~2.6.1:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.13.tgz#a20acbbec73c2e09f9007de5cda17104122e0010"
+  integrity sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5431,6 +5547,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+sync-fetch@^0.4.1:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.4.5.tgz#33ccf627ca72944ccdd3ebff581bb506be70f6a0"
+  integrity sha512-esiWJ7ixSKGpd9DJPBTC4ckChqdOjIwJfYhVHkcQ2Gnm41323p1TRmEI+esTQ9ppD+b5opps2OTEGTCGX5kF+g==
+  dependencies:
+    buffer "^5.7.1"
+    node-fetch "^2.6.1"
+
 synckit@^0.8.4:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.6.tgz#b69b7fbce3917c2673cbdc0d87fb324db4a5b409"
@@ -5511,6 +5635,11 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 trough@^2.0.0:
   version "2.1.0"
@@ -5840,6 +5969,11 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.12"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -5886,6 +6020,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
I resolved the issue by updating the mergeTrackedMarks function to always generate a new ID for marks during merge operations, preventing duplicate IDs.

Additionally, I implemented a workaround to consistently treat link nodes as insert operations. This avoids generating multiple suggestions when wrapping a portion of newly inserted text with a link. If the link continues to be treated as a wrap operation, it results in three separate suggestions: one for the left side of the pasted content, one for the link wrap, and one for the right side.