### PR TITLE
LEAN-4382 Text replacement fixes

### DIFF
--- a/src/steps/trackReplaceStep.ts
+++ b/src/steps/trackReplaceStep.ts
@@ -85,7 +85,12 @@ export function trackReplaceStep(
       changeSteps.splice(changeSteps.indexOf(backSpacedText))
     }
 
-    const textWasDeleted = !!changeSteps.length
+    /*
+    in reference to !(fromA === fromB) - if changed ranges didnt change with that step, we need to insert at the start of the new range to match 
+    where the user added inserted content
+    */
+    const textWasDeleted = !!changeSteps.length && !(fromA === fromB)
+    console.log(textWasDeleted)
     if (!backSpacedText && newSliceContent.size > 0) {
       log.info('newSliceContent', newSliceContent)
 
@@ -107,7 +112,7 @@ export function trackReplaceStep(
       changeSteps.push({
         type: 'insert-slice',
         from: textWasDeleted ? fromB : toA, // if text was deleted and some new text is inserted then the position has to set in accordance the newly set text
-        to: textWasDeleted ? fromB : toA, // it's not entirely clear why using "fromB" is needed at all but in cases where there areno content deleted before - it will gointo infinite loop if toB -1 is used
+        to: textWasDeleted ? fromB : toA, // it's not entirely clear why using "fromB" is needed at all but in cases where there are no content deleted before - it will go into infinite loop if toB -1 is used
         sliceWasSplit,
         slice: new Slice(fragment, openStart, openEnd) as ExposedSlice,
       })

--- a/src/utils/track-utils.ts
+++ b/src/utils/track-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Fragment, Node as PMNode, Slice } from 'prosemirror-model'
-import { Selection, TextSelection } from 'prosemirror-state'
+import { Selection, TextSelection, Transaction } from 'prosemirror-state'
 import { ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform'
 
 import { CHANGE_OPERATION } from '../types/change'
@@ -168,3 +168,6 @@ export function stepIsLift(
 ) {
   return gap.start < gap.end && gap.insert === 0 && gap.end === to && !node.isText
 }
+
+// @ts-ignore
+export const trFromHistory = (tr: Transaction) => Object.keys(tr.meta).find((s) => s.startsWith('history$'))


### PR DESCRIPTION
- Fix for text replacement case provided when replacing a word with a word starting with the same characters.
- Fix of history plugin detection. Sometime plugins key gets incremented, to prevent this I access the meta array directly to compare the keys in it.