### PR TITLE
LEAN-4401

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.3-LEAN-4401.0",
+  "version": "1.10.3",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/track-changes-plugin",
-  "version": "1.10.2",
+  "version": "1.10.3-LEAN-4401.0",
   "author": "Atypon Systems LLC",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Atypon-OpenSource/manuscripts-track-changes-plugin",

--- a/src/steps/trackReplaceStep.ts
+++ b/src/steps/trackReplaceStep.ts
@@ -82,6 +82,7 @@ export function trackReplaceStep(
 
     const backSpacedText = sameThingBackSpaced()
     if (backSpacedText) {
+      console.log('Detected backspacing')
       changeSteps.splice(changeSteps.indexOf(backSpacedText))
     }
 


### PR DESCRIPTION
Fixing deletion of dataTracked.inserted nodes grabbing some of the extra content at after the end, due to incorrect resolution of deletion steps, by avoiding creating a separate step for the child of a deleted node if the parent node was also deleted in the same transaction.